### PR TITLE
do not add css class "fixed-nav" to body if "onpage_menu" is set to false

### DIFF
--- a/templates/modular.html.twig
+++ b/templates/modular.html.twig
@@ -25,7 +25,12 @@
     {% endif %}
 {% endblock %}
 
-{% block body_classes %}{{ parent() }} fixed-nav{% endblock %}
+{% block body_classes %}
+    {{ parent() }}
+    {% if show_onpage_menu %}
+        fixed-nav
+    {% endif %}
+{% endblock %}
 
 {% block header_navigation %}
     {% if show_onpage_menu %}


### PR DESCRIPTION
If you're disabling "onpage_menu" for modular pages CSS class "fixed-nav" will be added to your body and you'll get some padding-top of 50px, which is only necessary for fixed navbar.

See Bootstrap documentations:
https://getbootstrap.com/components/#callout-navbar-fixed-top-padding
