### PR TITLE
Only set fixed-nav class on body element when show_onpage_menu is true

### DIFF
--- a/templates/modular.html.twig
+++ b/templates/modular.html.twig
@@ -25,7 +25,7 @@
     {% endif %}
 {% endblock %}
 
-{% block body_classes %}{{ parent() }} fixed-nav{% endblock %}
+{% block body_classes %}{{ parent() }} {% if show_onpage_menu %}fixed-nav{% endif %} {% endblock %}
 
 {% block header_navigation %}
     {% if show_onpage_menu %}


### PR DESCRIPTION
When creating a modular page with a static navigation the top padding is always set.
