### PR TITLE
Fixed wrong form class references

### DIFF
--- a/templates/forms/fields/checkbox/checkbox.html.twig
+++ b/templates/forms/fields/checkbox/checkbox.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
         <div class="checkbox">
             <label>

--- a/templates/forms/fields/checkboxes/checkboxes.html.twig
+++ b/templates/forms/fields/checkboxes/checkboxes.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|e }}</span>

--- a/templates/forms/fields/date/date.html.twig
+++ b/templates/forms/fields/date/date.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/datetime/datetime.html.twig
+++ b/templates/forms/fields/datetime/datetime.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/email/email.html.twig
+++ b/templates/forms/fields/email/email.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
 
         <label class="control-label col-sm-2">
             {% if field.help %}

--- a/templates/forms/fields/password/password.html.twig
+++ b/templates/forms/fields/password/password.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
         {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/radio/radio.html.twig
+++ b/templates/forms/fields/radio/radio.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/select/select.html.twig
+++ b/templates/forms/fields/select/select.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/text/text.html.twig
+++ b/templates/forms/fields/text/text.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
 
         <label class="control-label col-sm-2">
             {% if field.help %}

--- a/templates/forms/fields/textarea/textarea.html.twig
+++ b/templates/forms/fields/textarea/textarea.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
             <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/fields/upload/upload.html.twig
+++ b/templates/forms/fields/upload/upload.html.twig
@@ -1,6 +1,6 @@
 {% set value = (value is null ? field.default : value) %}
 
-<div class="form-field">
+<div class="form-group">
     <label class="control-label col-sm-2">
             {% if field.help %}
                 <span class="tooltip" data-asTooltip-position="w" title="{{ field.help|e }}">{{ field.label|default(field.name|capitalize)|t }}</span>

--- a/templates/forms/form.html.twig
+++ b/templates/forms/form.html.twig
@@ -1,1 +1,81 @@
-{% extends "forms/default/form.html.twig" %}
+{#{% extends "forms/default/form.html.twig" %}#}
+
+{% if form.message %}
+    {% if form.inline_errors and form.messages %}
+        <div class="alert notices {{ form.message_color ?: 'green' }}"><p>{{ "FORM.VALIDATION_FAIL"|t|raw }}</p></div>
+    {% else %}
+        <div class="alert notices {{ form.message_color ?: 'green' }}"><p>{{ form.message|raw }}</p></div>
+    {% endif %}
+{% endif %}
+{% set scope = scope ?: 'data.' %}
+{% set multipart = '' %}
+{% set method = form.method|upper|default('POST') %}
+
+{% for field in form.fields %}
+    {% if (method == 'POST' and field.type == 'file') %}
+        {% set multipart = ' enctype="multipart/form-data"' %}
+    {% endif %}
+{% endfor %}
+
+{% set action = form.action ? base_url ~ form.action : base_url ~ page.route ~ uri.params %}
+
+{% if (action == base_url_relative) %}
+    {% set action = base_url_relative ~ '/' ~ page.slug %}
+{% endif %}
+
+<form name="{{ form.name }}"
+      action="{{ action }}"
+      method="{{ method }}"{{ multipart }}
+      {% if form.id %}id="{{ form.id }}"{% endif %}
+      {% block form_classes %}
+      {% if form.classes %}class="{{ form.classes }}"{% endif %}
+      {% endblock %}
+>
+
+  {% block inner_markup_fields_start %}{% endblock %}
+
+  {% for field in form.fields %}
+    {% if field.type == 'file' %}
+        {% do assets.addJs('plugin://form/assets/form.min.js') %}
+    {% endif %}
+    {% set value = form.value(field.name) %}
+    {% include "forms/fields/#{field.type}/#{field.type}.html.twig" ignore missing %}
+  {% endfor %}
+
+  {% include "forms/fields/formname/formname.html.twig" %}
+
+  {% block inner_markup_fields_end %}{% endblock %}
+
+  {% block inner_markup_buttons_start %}
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+  {% endblock %}
+
+  {% for button in form.buttons %}
+      {% if button.outerclasses is defined %}<div class="{{ button.outerclasses }}">{% endif %}
+          {% if button.url %}
+              <a href="{{ button.url starts with 'http' ? button.url : url(button.url) }}">
+          {% endif %}
+          <button
+                {% if button.id %}id="{{ button.id }}"{% endif %}
+                {% block button_classes %}
+                class="{{ button.classes|default('button') }}"
+                {% endblock %}
+                {% if button.disabled %}disabled="disabled"{% endif %}
+                type="{{ button.type|default('submit') }}"
+            >
+                {{ button.value|t|default('Submit') }}
+          </button>
+          {% if button.url %}
+              </a>
+          {% endif %}
+      {% if button.outerclasses is defined %}</div>{% endif %}
+  {% endfor %}
+
+  {% block inner_markup_buttons_end %}
+    </div>
+  </div>
+  {% endblock %}
+
+  {{ nonce_field('form', 'form-nonce')|raw }}
+</form>


### PR DESCRIPTION
Fixed form wrong classes
It's just a hot fix, I'm not sure about the `templates/forms/form.html.twig` because there is a problem  with `<div class="buttons">` section from https://raw.githubusercontent.com/getgrav/grav-plugin-form/develop/templates/forms/default/form.html.twig